### PR TITLE
add missing dynamoDb permission

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -281,6 +281,7 @@ functions:
         Resource:
           - arn:aws:dynamodb:${self:provider.region}:*:table/${self:custom.tables.cocktail}
           - arn:aws:dynamodb:${self:provider.region}:*:table/${self:custom.tables.user}
+          - arn:aws:dynamodb:${self:provider.region}:*:table/${self:custom.tables.userGroupLink}
           - arn:aws:dynamodb:${self:provider.region}:*:table/${self:custom.tables.cocktailGroupLink}
 
 # ingredients


### PR DESCRIPTION
- fix deleteCocktail is not authorized to perform: dynamodb:GetItem on resource cocktail_fellow_*_userGroupLink